### PR TITLE
Replace Unidecode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "retrack"
-version = "2.2.1"
+version = "2.3.0"
 description = "A business rules engine"
 authors = ["Gabriel Guarisa <gabriel.guarisa@pier.digital>", "Nathalia Trotte <nathaliatrotte@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "retrack"
-version = "2.2.0"
+version = "2.2.1"
 description = "A business rules engine"
 authors = ["Gabriel Guarisa <gabriel.guarisa@pier.digital>", "Nathalia Trotte <nathaliatrotte@gmail.com>"]
 license = "MIT"
@@ -16,7 +16,6 @@ numpy = "^1.19.5"
 pydantic = "2.4.2"
 networkx = "^2.6.3"
 pandera = "^0.17.2"
-unidecode = "^1.3.7"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/retrack/engine/base.py
+++ b/retrack/engine/base.py
@@ -2,14 +2,8 @@ import typing
 
 import numpy as np
 import pandas as pd
-import pydantic
 
 from retrack.utils import constants
-
-
-class RuleMetadata(pydantic.BaseModel):
-    name: typing.Optional[str] = None
-    version: str
 
 
 class Execution:
@@ -77,6 +71,7 @@ class Execution:
             "states": self.states.to_dict(),
             "filters": {k: v.to_dict() for k, v in self.filters.items()},
             "result": self.result.to_dict(),
+            "has_ended": self.has_ended(),
         }
 
     @classmethod

--- a/retrack/engine/base.py
+++ b/retrack/engine/base.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from retrack.utils import constants
+from retrack.engine.schemas import ExecutionSchema
 
 
 class Execution:
@@ -73,6 +74,9 @@ class Execution:
             "result": self.result.to_dict(),
             "has_ended": self.has_ended(),
         }
+
+    def to_model(self) -> ExecutionSchema:
+        return ExecutionSchema(**self.to_dict())
 
     @classmethod
     def from_dict(cls, data: dict):

--- a/retrack/engine/executor.py
+++ b/retrack/engine/executor.py
@@ -228,10 +228,6 @@ class RuleExecutor:
                     msg = "Error executing a sub-rule node {} from rule {} version {}".format(
                         node_id, self.metadata.name, self.metadata.version
                     )
-                elif self.metadata.name is None:
-                    msg = "Error executing node {} in the sub-rule with version {}".format(
-                        node_id, self.metadata.version
-                    )
 
                 exception = exceptions.ExecutionException(
                     rule_metadata=self.metadata,

--- a/retrack/engine/executor.py
+++ b/retrack/engine/executor.py
@@ -3,7 +3,8 @@ import typing
 import pandas as pd
 import pydantic
 
-from retrack.engine.base import Execution, RuleMetadata
+from retrack.engine.base import Execution
+from retrack.engine.schemas import RuleMetadata
 from retrack.engine.request_manager import RequestManager
 from retrack.nodes.base import NodeKind, NodeMemoryType
 from retrack.utils import constants, exceptions
@@ -185,20 +186,22 @@ class RuleExecutor:
     def execute(
         self,
         payload_df: pd.DataFrame,
-        return_execution: bool = False,
-    ) -> typing.Union[pd.DataFrame, Execution]:
+        debug_mode: bool = False,
+    ) -> typing.Union[
+        pd.DataFrame, typing.Tuple[Execution, typing.Optional[Exception]]
+    ]:
         """Executes the rule.
 
         Args:
             payload_df (pd.DataFrame): The payload to be executed.
-            return_execution (bool, optional): If True, returns the execution object. Defaults to False.
+            debug_mode (bool, optional): If True, runs the rule in debug mode and returns the exception, if any. Defaults to False.
 
         Raises:
             exceptions.ExecutionException: If there is an error during execution.
             exceptions.ValidationException: If there is an error during validation.
 
         Returns:
-            typing.Union[pd.DataFrame, Execution]: The execution result.
+            typing.Union[pd.DataFrame, typing.Tuple[Execution, typing.Optional[Exception]]]: The result of the execution or a tuple with the execution and the exception, if any.
         """
         execution = Execution.from_payload(
             validated_payload=self.validate_payload(payload_df),
@@ -209,14 +212,16 @@ class RuleExecutor:
             try:
                 self.__run_node(node_id, execution=execution)
             except Exception as e:
-                raise exceptions.ExecutionException.from_metadata(
-                    self.metadata, node_id
-                ) from e
+                exception = exceptions.ExecutionException(self.metadata, node_id, e, execution)
+                if debug_mode:
+                    return execution, exception
+
+                raise exception from e
 
             if execution.has_ended():
                 break
 
-        if return_execution:
-            return execution
+        if debug_mode:
+            return execution, None
 
         return execution.result

--- a/retrack/engine/executor.py
+++ b/retrack/engine/executor.py
@@ -212,7 +212,9 @@ class RuleExecutor:
             try:
                 self.__run_node(node_id, execution=execution)
             except Exception as e:
-                exception = exceptions.ExecutionException(self.metadata, node_id, e, execution)
+                exception = exceptions.ExecutionException(
+                    self.metadata, node_id, e, execution
+                )
                 if debug_mode:
                     return execution, exception
 

--- a/retrack/engine/executor.py
+++ b/retrack/engine/executor.py
@@ -225,8 +225,12 @@ class RuleExecutor:
             except Exception as e:
                 msg = None
                 if isinstance(e, exceptions.ExecutionException):
-                    msg = "Error executing sub-rule in node {} from rule {} version {}".format(
+                    msg = "Error executing a sub-rule node {} from rule {} version {}".format(
                         node_id, self.metadata.name, self.metadata.version
+                    )
+                elif self.metadata.name is None:
+                    msg = "Error executing node {} in the sub-rule with version {}".format(
+                        node_id, self.metadata.version
                     )
 
                 exception = exceptions.ExecutionException(

--- a/retrack/engine/rule.py
+++ b/retrack/engine/rule.py
@@ -45,7 +45,7 @@ class Rule(RuleMetadata):
             graph_data, nodes_registry, dynamic_nodes_registry, validator_registry
         )
         version = graph.validate_version(
-            graph_data, raise_if_null_version, validate_version
+            graph_data, raise_if_null_version, validate_version, name
         )
         graph_data = graph_data
 

--- a/retrack/engine/rule.py
+++ b/retrack/engine/rule.py
@@ -3,7 +3,7 @@ import typing
 import pydantic
 
 from retrack import validators
-from retrack.engine.base import RuleMetadata
+from retrack.engine.schemas import RuleMetadata
 from retrack.engine.executor import RuleExecutor
 from retrack.utils import graph
 from retrack.utils.component_registry import ComponentRegistry

--- a/retrack/engine/schemas.py
+++ b/retrack/engine/schemas.py
@@ -1,0 +1,69 @@
+import pydantic
+import typing
+
+
+class RuleMetadata(pydantic.BaseModel):
+    name: typing.Optional[str] = pydantic.Field(
+        None, description="The name of the rule"
+    )
+    version: str = pydantic.Field(..., description="The version of the rule")
+
+
+class ExecutionSchema(pydantic.BaseModel):
+    payload: typing.Any = pydantic.Field(
+        ..., description="The payload of the execution"
+    )
+    states: typing.Any = pydantic.Field(
+        ..., description="The states of the execution"
+    )
+    filters: typing.Dict[str, typing.Any] = pydantic.Field(
+        ..., description="The filters of the execution"
+    )
+    result: typing.Any = pydantic.Field(
+        ..., description="The result of the execution"
+    )
+    has_ended: bool = pydantic.Field(
+        ..., description="If the execution has ended"
+    )
+
+
+class ExecutionMetadata(RuleMetadata):
+    node_id: typing.Optional[str] = pydantic.Field(None, description="The node id")
+    execution: typing.Optional[ExecutionSchema] = pydantic.Field(None, description="Metadata of the rule execution")
+
+
+class ExceptionSchema(pydantic.BaseModel):
+    msg: str = pydantic.Field(..., description="The exception message")
+    exception_type: str = pydantic.Field(..., description="The exception type")
+    traceback: typing.Any = pydantic.Field(..., description="The exception traceback")
+
+
+class DetailSchema(pydantic.BaseModel):
+    msg: str = pydantic.Field(
+        ...,
+        description="A human-readable explanation specific to this occurrence of the problem. This field’s value can be localized",
+    )
+    type_: str = pydantic.Field(
+        ..., alias="type", description="The type of the problem"
+    )
+    exception: ExceptionSchema = pydantic.Field(
+        ..., description="The exception that caused the problem"
+    )
+
+
+class ErrorSchema(pydantic.BaseModel):
+    title: str = pydantic.Field(
+        ...,
+        description="A short, human-readable summary of the problem that SHOULD NOT change from occurrence to occurrence of the problem",
+    )
+    detail: DetailSchema = pydantic.Field(
+        ...,
+        description="A explanation specific to this occurrence of the problem. This field’s value can be localized",
+    )
+    status: str = pydantic.Field(
+        ...,
+        description="The HTTP status code applicable to this problem, expressed as a string value",
+    )
+    metadata: ExecutionMetadata = pydantic.Field(
+        ..., description="Rule metadata"
+    )

--- a/retrack/engine/schemas.py
+++ b/retrack/engine/schemas.py
@@ -6,19 +6,27 @@ class RuleMetadata(pydantic.BaseModel):
     name: typing.Optional[str] = pydantic.Field(
         None, description="The name of the rule"
     )
-    version: str = pydantic.Field(..., description="The version of the rule")
+    version: typing.Optional[str] = pydantic.Field(
+        ..., description="The version of the rule"
+    )
 
 
 class ExecutionSchema(pydantic.BaseModel):
-    payload: typing.Any = pydantic.Field(
-        ..., description="The payload of the execution"
+    payload: typing.Optional[typing.Any] = pydantic.Field(
+        None, description="The payload of the execution"
     )
-    states: typing.Any = pydantic.Field(..., description="The states of the execution")
-    filters: typing.Dict[str, typing.Any] = pydantic.Field(
-        ..., description="The filters of the execution"
+    states: typing.Optional[typing.Any] = pydantic.Field(
+        None, description="The states of the execution"
     )
-    result: typing.Any = pydantic.Field(..., description="The result of the execution")
-    has_ended: bool = pydantic.Field(..., description="If the execution has ended")
+    filters: typing.Optional[typing.Dict[str, typing.Any]] = pydantic.Field(
+        None, description="The filters of the execution"
+    )
+    result: typing.Optional[typing.Any] = pydantic.Field(
+        None, description="The result of the execution"
+    )
+    has_ended: typing.Optional[bool] = pydantic.Field(
+        None, description="If the execution has ended"
+    )
 
 
 class ExecutionMetadata(RuleMetadata):
@@ -29,9 +37,11 @@ class ExecutionMetadata(RuleMetadata):
 
 
 class ExceptionSchema(pydantic.BaseModel):
-    msg: str = pydantic.Field(..., description="The exception message")
+    msg: typing.Any = pydantic.Field(..., description="The exception message")
     exception_type: str = pydantic.Field(..., description="The exception type")
-    traceback: typing.Any = pydantic.Field(..., description="The exception traceback")
+    traceback: typing.Optional[typing.Any] = pydantic.Field(
+        None, description="The exception traceback", exclude=True
+    )
 
 
 class DetailSchema(pydantic.BaseModel):

--- a/retrack/engine/schemas.py
+++ b/retrack/engine/schemas.py
@@ -13,23 +13,19 @@ class ExecutionSchema(pydantic.BaseModel):
     payload: typing.Any = pydantic.Field(
         ..., description="The payload of the execution"
     )
-    states: typing.Any = pydantic.Field(
-        ..., description="The states of the execution"
-    )
+    states: typing.Any = pydantic.Field(..., description="The states of the execution")
     filters: typing.Dict[str, typing.Any] = pydantic.Field(
         ..., description="The filters of the execution"
     )
-    result: typing.Any = pydantic.Field(
-        ..., description="The result of the execution"
-    )
-    has_ended: bool = pydantic.Field(
-        ..., description="If the execution has ended"
-    )
+    result: typing.Any = pydantic.Field(..., description="The result of the execution")
+    has_ended: bool = pydantic.Field(..., description="If the execution has ended")
 
 
 class ExecutionMetadata(RuleMetadata):
     node_id: typing.Optional[str] = pydantic.Field(None, description="The node id")
-    execution: typing.Optional[ExecutionSchema] = pydantic.Field(None, description="Metadata of the rule execution")
+    execution: typing.Optional[ExecutionSchema] = pydantic.Field(
+        None, description="Metadata of the rule execution"
+    )
 
 
 class ExceptionSchema(pydantic.BaseModel):
@@ -64,6 +60,4 @@ class ErrorSchema(pydantic.BaseModel):
         ...,
         description="The HTTP status code applicable to this problem, expressed as a string value",
     )
-    metadata: ExecutionMetadata = pydantic.Field(
-        ..., description="Rule metadata"
-    )
+    metadata: ExecutionMetadata = pydantic.Field(..., description="Rule metadata")

--- a/retrack/nodes/dynamic/flow.py
+++ b/retrack/nodes/dynamic/flow.py
@@ -56,7 +56,6 @@ def flow_factory(
 
     class FlowV0(BaseFlowV0Model):
         def run(self, **kwargs) -> typing.Dict[str, typing.Any]:
-            print(kwargs.keys())
             input_args = {}
             for name, value in kwargs.items():
                 if name.startswith("input_"):

--- a/retrack/utils/exceptions.py
+++ b/retrack/utils/exceptions.py
@@ -5,47 +5,123 @@ from retrack.engine.schemas import (
     DetailSchema,
     ExceptionSchema,
     ExecutionMetadata,
+    RuleMetadata,
+    ExecutionSchema,
 )
+
+
+def create_exception_schema(raised_exception: Exception) -> ExceptionSchema:
+    traceback_str = None
+    try:
+        traceback_str = traceback.format_exception(raised_exception)
+    except Exception:
+        pass
+
+    raised_message = str(raised_exception)
+    if hasattr(raised_exception, "error"):
+        raised_message = raised_exception.error.model_dump()
+
+    return ExceptionSchema(
+        msg=raised_message,
+        exception_type=type(raised_exception).__name__,
+        traceback=traceback_str,
+    )
 
 
 class ExecutionException(Exception):
     """Exception raised when an error occurs during execution of a command."""
 
-    def __init__(self, rule_metadata, node_id, e, execution):
+    def __init__(
+        self,
+        rule_metadata: RuleMetadata,
+        execution_data: ExecutionSchema,
+        node_id: int,
+        raised_exception: Exception,
+        msg: str = None,
+    ):
+        msg = (
+            msg
+            or f"Error executing node {node_id} from rule {rule_metadata.name} version {rule_metadata.version}"
+        )
+
         self.error = ErrorSchema(
             title="Execution error",
             status="500",
             detail=DetailSchema(
-                msg=f"Error executing node {node_id} from rule {rule_metadata.name} version {rule_metadata.version}",
+                msg=msg,
                 type="ExecutionException",
-                exception=ExceptionSchema(
-                    msg=str(e),
-                    exception_type=type(e).__name__,
-                    traceback=traceback.format_exception(e),
-                ),
+                exception=create_exception_schema(raised_exception),
             ),
             metadata=ExecutionMetadata(
                 name=rule_metadata.name,
                 version=rule_metadata.version,
                 node_id=node_id,
-                execution=execution.to_dict(),
+                execution=execution_data,
             ),
         )
 
-        super().__init__(self.error.model_dump())  # TODO: padronizar mensagens de erros
+        super().__init__(self.error.model_dump())
 
 
 class ValidationException(Exception):
     """Exception raised when an error occurs during validation of a command."""
 
-    @classmethod
-    def from_metadata(cls, metadata, payload_df: pd.DataFrame):
-        return cls(
-            f"Error validating rule {metadata.name} version {metadata.version} with payload {payload_df}"
+    def __init__(
+        self,
+        rule_metadata: RuleMetadata,
+        payload_df: pd.DataFrame,
+        raised_exception: Exception,
+        msg: str = None,
+    ):
+        msg = (
+            msg
+            or f"Error validating payload for rule {rule_metadata.name} version {rule_metadata.version}"
         )
+
+        self.error = ErrorSchema(
+            title="Validation error",
+            status="400",
+            detail=DetailSchema(
+                msg=msg,
+                type="ValidationException",
+                exception=create_exception_schema(raised_exception),
+            ),
+            metadata=ExecutionMetadata(
+                name=rule_metadata.name,
+                version=rule_metadata.version,
+                node_id=None,
+                execution=ExecutionSchema(payload=str(payload_df)),
+            ),
+        )
+
+        super().__init__(self.error.model_dump())
 
 
 class InvalidVersionException(Exception):
     """Exception raised when an invalid version is found."""
 
-    pass
+    def __init__(
+        self, rule_metadata: RuleMetadata, raised_exception: Exception, msg: str = None
+    ):
+        msg = (
+            msg
+            or f"Invalid version for rule {rule_metadata.name} version {rule_metadata.version}"
+        )
+
+        self.error = ErrorSchema(
+            title="Invalid version",
+            status="400",
+            detail=DetailSchema(
+                msg=msg,
+                type="InvalidVersionException",
+                exception=create_exception_schema(raised_exception),
+            ),
+            metadata=ExecutionMetadata(
+                name=rule_metadata.name,
+                version=rule_metadata.version,
+                node_id=None,
+                execution=None,
+            ),
+        )
+
+        super().__init__(self.error.model_dump())

--- a/retrack/utils/exceptions.py
+++ b/retrack/utils/exceptions.py
@@ -1,14 +1,35 @@
 import pandas as pd
+import traceback
+from retrack.engine.schemas import (
+    ErrorSchema,
+    DetailSchema,
+    ExceptionSchema,
+    ExecutionMetadata,
+)
 
 
 class ExecutionException(Exception):
     """Exception raised when an error occurs during execution of a command."""
 
-    @classmethod
-    def from_metadata(cls, metadata, node_id: str):
-        return cls(
-            f"Error executing node {node_id} from rule {metadata.name} version {metadata.version}"
+    def __init__(self, rule_metadata, node_id, e, execution):
+        self.error = ErrorSchema(
+            title="Execution error",
+            status="500",
+            detail=DetailSchema(
+                msg=f"Error executing node {node_id} from rule {rule_metadata.name} version {rule_metadata.version}",
+                type="ExecutionException",
+                exception=ExceptionSchema(
+                    msg=str(e),
+                    exception_type=type(e).__name__,
+                    traceback=traceback.format_exception(e),
+                ),
+            ),
+            metadata=ExecutionMetadata(
+                name=rule_metadata.name, version=rule_metadata.version, node_id=node_id, execution=execution.to_dict()
+            ),
         )
+
+        super().__init__(self.error.model_dump())  # TODO: padronizar mensagens de erros
 
 
 class ValidationException(Exception):

--- a/retrack/utils/exceptions.py
+++ b/retrack/utils/exceptions.py
@@ -25,7 +25,10 @@ class ExecutionException(Exception):
                 ),
             ),
             metadata=ExecutionMetadata(
-                name=rule_metadata.name, version=rule_metadata.version, node_id=node_id, execution=execution.to_dict()
+                name=rule_metadata.name,
+                version=rule_metadata.version,
+                node_id=node_id,
+                execution=execution.to_dict(),
             ),
         )
 

--- a/retrack/utils/graph.py
+++ b/retrack/utils/graph.py
@@ -6,6 +6,7 @@ import unicodedata
 from retrack.utils.component_registry import ComponentRegistry
 from retrack.utils.registry import Registry
 from retrack.utils import exceptions
+from retrack.engine.schemas import RuleMetadata
 
 
 def normalize_string(some_string: str) -> str:
@@ -17,7 +18,7 @@ def normalize_string(some_string: str) -> str:
 
 
 def validate_version(
-    graph_data: dict, raise_if_null_version: bool, validate_version: bool
+    graph_data: dict, raise_if_null_version: bool, validate_version: bool, name: str
 ) -> str:
     version = graph_data.get("version", None)
 
@@ -32,8 +33,9 @@ def validate_version(
     if version is None:
         if raise_if_null_version:
             raise exceptions.InvalidVersionException(
-                "Missing version. "
-                + "Make sure to set a version in the graph data or set raise_if_null_version to False."
+                rule_metadata=RuleMetadata(name=name, version=None),
+                raised_exception=ValueError("Version is null"),
+                msg="Version is null",
             )
 
         return f"{calculated_hash}.dynamic"
@@ -42,8 +44,11 @@ def validate_version(
 
     if file_version_hash != calculated_hash and validate_version:
         raise exceptions.InvalidVersionException(
-            "Invalid version. "
-            + f"Graph data has changed and the hash is different: {calculated_hash} != {file_version_hash}"
+            rule_metadata=RuleMetadata(name=name, version=version),
+            raised_exception=ValueError(
+                f"Version hash {file_version_hash} does not match calculated hash {calculated_hash}"
+            ),
+            msg="Version hash does not match calculated hash",
         )
 
     return version

--- a/retrack/utils/graph.py
+++ b/retrack/utils/graph.py
@@ -1,11 +1,19 @@
 import hashlib
 import json
 
-from unidecode import unidecode
+import unicodedata
 
 from retrack.utils.component_registry import ComponentRegistry
 from retrack.utils.registry import Registry
 from retrack.utils import exceptions
+
+
+def normalize_string(some_string: str) -> str:
+    return (
+        unicodedata.normalize("NFKD", some_string)
+        .encode("ascii", "ignore")
+        .decode("utf-8")
+    )
 
 
 def validate_version(
@@ -18,7 +26,7 @@ def validate_version(
         .replace("\\", "")
         .replace('"', "")
     )
-    graph_json_content = unidecode(graph_json_content, errors="strict")
+    graph_json_content = normalize_string(graph_json_content)
     calculated_hash = hashlib.sha256(graph_json_content.encode()).hexdigest()[:10]
 
     if version is None:


### PR DESCRIPTION
This PR makes the following changes:
- Removes the unidecode library;
- Standardizes exceptions to return a message similar to the one shown below:

```json
{
  "title": "Execution error",
  "detail": {
    "msg": "Error executing a sub-rule node 2 from rule example.json version 9116848f00.2024-03-06",
    "type_": "ExecutionException",
    "exception": {
      "msg": {
        "title": "Execution error",
        "detail": {
          "msg": "Error executing node 4 from rule None version 03f1c81a79.dynamic",
          "type_": "ExecutionException",
          "exception": {
            "msg": "could not convert string to float: 'a'",
            "exception_type": "ValueError"
          }
        },
        "status": "500",
        "metadata": {
          "name": null,
          "version": "03f1c81a79.dynamic",
          "node_id": "4",
          "execution": {
            "payload": {
              "frequency": { "0": "a" },
              "market_value_cents": { "0": "8887300" },
              "user_age": { "0": "23" },
              "uf": { "0": "BA" }
            },
            "states": {
              "2@output_value": { "0": "a" },
              "3@output_value": { "0": "8887300" },
              "output": { "0": null },
              "message": { "0": null }
            },
            "filters": {},
            "result": { "output": { "0": null }, "message": { "0": null } },
            "has_ended": false
          }
        }
      },
      "exception_type": "ExecutionException"
    }
  },
  "status": "500",
  "metadata": {
    "name": "example.json",
    "version": "9116848f00.2024-03-06",
    "node_id": "2",
    "execution": {
      "payload": {
        "frequency": { "0": "a" },
        "market_value_cents": { "0": "8887300" },
        "user_age": { "0": "23" },
        "uf": { "0": "BA" }
      },
      "states": {
        "6@output_value": { "0": "a" },
        "7@output_value": { "0": "8887300" },
        "8@output_value": { "0": "23" },
        "9@output_value": { "0": "BA" },
        "11@output_value": { "0": "8887300" },
        "output": { "0": null },
        "message": { "0": null }
      },
      "filters": {},
      "result": { "output": { "0": null }, "message": { "0": null } },
      "has_ended": false
    }
  }
}
```