### PR TITLE
RequestManager lifecycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "retrack"
-version = "2.10.1"
+version = "2.10.2a1"
 description = "A business rules engine"
 authors = ["Gabriel Guarisa <gabriel.guarisa@pier.digital>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "retrack"
-version = "2.10.2a1"
+version = "2.10.2"
 description = "A business rules engine"
 authors = ["Gabriel Guarisa <gabriel.guarisa@pier.digital>"]
 license = "MIT"

--- a/retrack/__init__.py
+++ b/retrack/__init__.py
@@ -5,6 +5,7 @@ from retrack.engine.base import Execution
 from retrack.nodes import registry as nodes_registry, dynamic_nodes_registry
 from retrack.nodes.base import BaseNode, InputConnectionModel, OutputConnectionModel
 from retrack.nodes.connectors import BaseConnector
+from retrack.engine.request_manager import RequestManager
 
 __all__ = [
     "Rule",
@@ -17,4 +18,5 @@ __all__ = [
     "InputConnectionModel",
     "OutputConnectionModel",
     "BaseConnector",
+    "RequestManager",
 ]


### PR DESCRIPTION
Add functions to erase, reset and set the RequestManager in the RuleExecutor.