### PR TITLE
Add Duplicate Node Names Validator

### DIFF
--- a/retrack/validators/__init__.py
+++ b/retrack/validators/__init__.py
@@ -3,6 +3,7 @@ from retrack.validators.base import BaseValidator
 from retrack.validators.check_is_dag import CheckIsDAG
 from retrack.validators.node_exists import NodeExistsValidator
 from retrack.validators.node_validator import IntervalCatV0Validator
+from retrack.validators.unique_node_name import UniqueNodeNameValidator
 
 
 def registry() -> Registry:
@@ -13,6 +14,7 @@ def registry() -> Registry:
     )
     _registry.register("check_is_dag", CheckIsDAG())
     _registry.register("interval_cat_v0", IntervalCatV0Validator())
+    _registry.register("unique_node_name", UniqueNodeNameValidator())
     return _registry
 
 

--- a/retrack/validators/unique_node_name.py
+++ b/retrack/validators/unique_node_name.py
@@ -1,0 +1,52 @@
+from typing import Optional
+from retrack.validators.base import BaseValidator
+
+
+class UniqueNodeNameValidator(BaseValidator):
+    """Validator that checks if node name is unique across the graph."""
+
+    def validate(self, graph_data: dict, **kwargs) -> tuple[bool, Optional[str]]:
+        """Validate that all node name values are unique in the graph.
+
+        Args:
+            graph_data: The graph data to validate.
+
+        Returns:
+            A tuple (is_valid, error_message). is_valid is True if all node names are unique,
+            False otherwise. error_message contains details about duplicate names.
+        """
+        nodes = graph_data.get("nodes", {})
+
+        names_count = {}
+        node_ids_by_name = {}
+
+        for node_id, node in nodes.items():
+            node_name = node.get("name")
+            if node_name in ("Input", "Output"):
+                continue
+
+            data = node.get("data", {})
+            name = data.get("name")
+
+            if name is not None:
+                if name not in names_count:
+                    names_count[name] = 0
+                    node_ids_by_name[name] = []
+
+                names_count[name] += 1
+                node_ids_by_name[name].append(node_id)
+
+        duplicates = {
+            name: node_ids
+            for name, node_ids in node_ids_by_name.items()
+            if names_count[name] > 1
+        }
+
+        if duplicates:
+            duplicate_details = ", ".join(
+                f"'{name}' (nodes: {', '.join(map(str, node_ids))})"
+                for name, node_ids in duplicates.items()
+            )
+            return False, f"Duplicate node names found: {duplicate_details}"
+
+        return True, None

--- a/tests/resources/invalid/duplicate-node-names.json
+++ b/tests/resources/invalid/duplicate-node-names.json
@@ -1,0 +1,370 @@
+{
+  "id": "demo@0.1.0",
+  "nodes": {
+    "64de388213a30001": {
+      "id": "64de388213a30001",
+      "name": "Start",
+      "data": {},
+      "outputs": {
+        "output_up_void": {
+          "connections": [
+            {
+              "node": "43294d550df7b5ec",
+              "input": "input_void"
+            }
+          ]
+        },
+        "output_down_void": {
+          "connections": [
+            {
+              "node": "430edbcc30da4325",
+              "input": "input_void"
+            }
+          ]
+        }
+      },
+      "inputs": {}
+    },
+    "43294d550df7b5ec": {
+      "id": "43294d550df7b5ec",
+      "name": "Input",
+      "data": {
+        "name": "number",
+        "default": ""
+      },
+      "outputs": {
+        "output_value": {
+          "connections": [
+            {
+              "node": "3e3e3c467f618f64",
+              "input": "input_number"
+            }
+          ]
+        }
+      },
+      "inputs": {
+        "input_void": {
+          "connections": [
+            {
+              "node": "64de388213a30001",
+              "output": "output_up_void"
+            }
+          ]
+        }
+      }
+    },
+    "dcab49930d0ed13f": {
+      "id": "dcab49930d0ed13f",
+      "name": "If",
+      "data": {},
+      "outputs": {
+        "output_then_filter": {
+          "connections": [
+            {
+              "node": "03aef1138a7508d6",
+              "input": "input_void"
+            }
+          ]
+        },
+        "output_else_filter": {
+          "connections": [
+            {
+              "node": "e72726ed9612c416",
+              "input": "input_void"
+            }
+          ]
+        }
+      },
+      "inputs": {
+        "input_bool": {
+          "connections": [
+            {
+              "node": "dad6ef6c48978e77",
+              "output": "output_bool"
+            }
+          ]
+        }
+      }
+    },
+    "3e3e3c467f618f64": {
+      "id": "3e3e3c467f618f64",
+      "name": "FlowV0",
+      "data": {
+        "value": "{\"id\":\"demo@0.1.0\",\"nodes\":{\"bbf11385f3999284\":{\"id\":\"bbf11385f3999284\",\"name\":\"Start\",\"data\":{},\"outputs\":{\"output_up_void\":{\"connections\":[{\"node\":\"571b4c64308b772c\",\"input\":\"input_void\"}]},\"output_down_void\":{\"connections\":[{\"node\":\"85732e121f80e263\",\"input\":\"input_void\"}]}},\"inputs\":{}},\"72f88dfc53235c5f\":{\"id\":\"72f88dfc53235c5f\",\"name\":\"Output\",\"data\":{\"message\":\"\"},\"outputs\":{},\"inputs\":{\"input_value\":{\"connections\":[{\"node\":\"0801f173504b8abe\",\"output\":\"output_bool\"}]}}},\"571b4c64308b772c\":{\"id\":\"571b4c64308b772c\",\"name\":\"Input\",\"data\":{\"name\":\"number\",\"default\":\"\"},\"outputs\":{\"output_value\":{\"connections\":[{\"node\":\"0801f173504b8abe\",\"input\":\"input_value_0\"}]}},\"inputs\":{\"input_void\":{\"connections\":[{\"node\":\"bbf11385f3999284\",\"output\":\"output_up_void\"}]}}},\"85732e121f80e263\":{\"id\":\"85732e121f80e263\",\"name\":\"Constant\",\"data\":{\"value\":\"1\"},\"outputs\":{\"output_value\":{\"connections\":[{\"node\":\"0801f173504b8abe\",\"input\":\"input_value_1\"}]}},\"inputs\":{\"input_void\":{\"connections\":[{\"node\":\"bbf11385f3999284\",\"output\":\"output_down_void\"}]}}},\"0801f173504b8abe\":{\"id\":\"0801f173504b8abe\",\"name\":\"Check\",\"data\":{\"operator\":\"==\"},\"outputs\":{\"output_bool\":{\"connections\":[{\"node\":\"72f88dfc53235c5f\",\"input\":\"input_value\"}]}},\"inputs\":{\"input_value_0\":{\"connections\":[{\"node\":\"571b4c64308b772c\",\"output\":\"output_value\"}]},\"input_value_1\":{\"connections\":[{\"node\":\"85732e121f80e263\",\"output\":\"output_value\"}]}}}},\"version\":\"dd326f76aa.2026-01-28\"}",
+        "name": "is_equal"
+      },
+      "outputs": {
+        "output_value": {
+          "connections": [
+            {
+              "node": "dad6ef6c48978e77",
+              "input": "input_value_0"
+            }
+          ]
+        }
+      },
+      "inputs": {
+        "input_number": {
+          "connections": [
+            {
+              "node": "43294d550df7b5ec",
+              "output": "output_value"
+            }
+          ]
+        }
+      }
+    },
+    "430edbcc30da4325": {
+      "id": "430edbcc30da4325",
+      "name": "Bool",
+      "data": {
+        "value": true
+      },
+      "outputs": {
+        "output_bool": {
+          "connections": [
+            {
+              "node": "dad6ef6c48978e77",
+              "input": "input_value_1"
+            }
+          ]
+        }
+      },
+      "inputs": {
+        "input_void": {
+          "connections": [
+            {
+              "node": "64de388213a30001",
+              "output": "output_down_void"
+            }
+          ]
+        }
+      }
+    },
+    "dad6ef6c48978e77": {
+      "id": "dad6ef6c48978e77",
+      "name": "Check",
+      "data": {
+        "operator": "=="
+      },
+      "outputs": {
+        "output_bool": {
+          "connections": [
+            {
+              "node": "dcab49930d0ed13f",
+              "input": "input_bool"
+            }
+          ]
+        }
+      },
+      "inputs": {
+        "input_value_0": {
+          "connections": [
+            {
+              "node": "3e3e3c467f618f64",
+              "output": "output_value"
+            }
+          ]
+        },
+        "input_value_1": {
+          "connections": [
+            {
+              "node": "430edbcc30da4325",
+              "output": "output_bool"
+            }
+          ]
+        }
+      }
+    },
+    "03aef1138a7508d6": {
+      "id": "03aef1138a7508d6",
+      "name": "Bool",
+      "data": {
+        "value": true
+      },
+      "outputs": {
+        "output_bool": {
+          "connections": [
+            {
+              "node": "fdf9292649a66368",
+              "input": "input_value"
+            }
+          ]
+        }
+      },
+      "inputs": {
+        "input_void": {
+          "connections": [
+            {
+              "node": "dcab49930d0ed13f",
+              "output": "output_then_filter"
+            }
+          ]
+        }
+      }
+    },
+    "fdf9292649a66368": {
+      "id": "fdf9292649a66368",
+      "name": "Output",
+      "data": {
+        "message": "is_equal"
+      },
+      "outputs": {},
+      "inputs": {
+        "input_value": {
+          "connections": [
+            {
+              "node": "03aef1138a7508d6",
+              "output": "output_bool"
+            }
+          ]
+        }
+      }
+    },
+    "e72726ed9612c416": {
+      "id": "e72726ed9612c416",
+      "name": "Input",
+      "data": {
+        "name": "number",
+        "default": ""
+      },
+      "outputs": {
+        "output_value": {
+          "connections": [
+            {
+              "node": "760d4b5cfa5920f9",
+              "input": "input_void"
+            },
+            {
+              "node": "22cb5788ed6296b9",
+              "input": "input_number"
+            }
+          ]
+        }
+      },
+      "inputs": {
+        "input_void": {
+          "connections": [
+            {
+              "node": "dcab49930d0ed13f",
+              "output": "output_else_filter"
+            }
+          ]
+        }
+      }
+    },
+    "760d4b5cfa5920f9": {
+      "id": "760d4b5cfa5920f9",
+      "name": "Bool",
+      "data": {
+        "value": false
+      },
+      "outputs": {
+        "output_bool": {
+          "connections": [
+            {
+              "node": "98353c19e6bf031a",
+              "input": "input_value_1"
+            }
+          ]
+        }
+      },
+      "inputs": {
+        "input_void": {
+          "connections": [
+            {
+              "node": "e72726ed9612c416",
+              "output": "output_value"
+            }
+          ]
+        }
+      }
+    },
+    "22cb5788ed6296b9": {
+      "id": "22cb5788ed6296b9",
+      "name": "FlowV0",
+      "data": {
+        "value": "{\"id\":\"demo@0.1.0\",\"nodes\":{\"bbf11385f3999284\":{\"id\":\"bbf11385f3999284\",\"name\":\"Start\",\"data\":{},\"outputs\":{\"output_up_void\":{\"connections\":[{\"node\":\"571b4c64308b772c\",\"input\":\"input_void\"}]},\"output_down_void\":{\"connections\":[{\"node\":\"85732e121f80e263\",\"input\":\"input_void\"}]}},\"inputs\":{}},\"72f88dfc53235c5f\":{\"id\":\"72f88dfc53235c5f\",\"name\":\"Output\",\"data\":{\"message\":\"\"},\"outputs\":{},\"inputs\":{\"input_value\":{\"connections\":[{\"node\":\"0801f173504b8abe\",\"output\":\"output_bool\"}]}}},\"571b4c64308b772c\":{\"id\":\"571b4c64308b772c\",\"name\":\"Input\",\"data\":{\"name\":\"number\",\"default\":\"\"},\"outputs\":{\"output_value\":{\"connections\":[{\"node\":\"0801f173504b8abe\",\"input\":\"input_value_0\"}]}},\"inputs\":{\"input_void\":{\"connections\":[{\"node\":\"bbf11385f3999284\",\"output\":\"output_up_void\"}]}}},\"85732e121f80e263\":{\"id\":\"85732e121f80e263\",\"name\":\"Constant\",\"data\":{\"value\":\"1\"},\"outputs\":{\"output_value\":{\"connections\":[{\"node\":\"0801f173504b8abe\",\"input\":\"input_value_1\"}]}},\"inputs\":{\"input_void\":{\"connections\":[{\"node\":\"bbf11385f3999284\",\"output\":\"output_down_void\"}]}}},\"0801f173504b8abe\":{\"id\":\"0801f173504b8abe\",\"name\":\"Check\",\"data\":{\"operator\":\"==\"},\"outputs\":{\"output_bool\":{\"connections\":[{\"node\":\"72f88dfc53235c5f\",\"input\":\"input_value\"}]}},\"inputs\":{\"input_value_0\":{\"connections\":[{\"node\":\"571b4c64308b772c\",\"output\":\"output_value\"}]},\"input_value_1\":{\"connections\":[{\"node\":\"85732e121f80e263\",\"output\":\"output_value\"}]}}}},\"version\":\"dd326f76aa.2026-01-28\"}",
+        "name": "is_equal"
+      },
+      "outputs": {
+        "output_value": {
+          "connections": [
+            {
+              "node": "98353c19e6bf031a",
+              "input": "input_value_0"
+            }
+          ]
+        }
+      },
+      "inputs": {
+        "input_number": {
+          "connections": [
+            {
+              "node": "e72726ed9612c416",
+              "output": "output_value"
+            }
+          ]
+        }
+      }
+    },
+    "98353c19e6bf031a": {
+      "id": "98353c19e6bf031a",
+      "name": "Check",
+      "data": {
+        "operator": "=="
+      },
+      "outputs": {
+        "output_bool": {
+          "connections": [
+            {
+              "node": "61dc887d263e1f92",
+              "input": "input_void"
+            }
+          ]
+        }
+      },
+      "inputs": {
+        "input_value_0": {
+          "connections": [
+            {
+              "node": "22cb5788ed6296b9",
+              "output": "output_value"
+            }
+          ]
+        },
+        "input_value_1": {
+          "connections": [
+            {
+              "node": "760d4b5cfa5920f9",
+              "output": "output_bool"
+            }
+          ]
+        }
+      }
+    },
+    "61dc887d263e1f92": {
+      "id": "61dc887d263e1f92",
+      "name": "Constant",
+      "data": {
+        "value": "is_not_equal"
+      },
+      "outputs": {
+        "output_value": {
+          "connections": []
+        }
+      },
+      "inputs": {
+        "input_void": {
+          "connections": [
+            {
+              "node": "98353c19e6bf031a",
+              "output": "output_bool"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "version": "5d292ee38d.2026-01-28"
+}

--- a/tests/test_engine/test_executor.py
+++ b/tests/test_engine/test_executor.py
@@ -395,6 +395,11 @@ async def test_rules_with_subrules_with_conditions():
             [{"age": 40}],
             "Invalid numeric values in interval columns in node 3",
         ),
+        (
+            "duplicate-node-names",
+            [{"number": 1}],
+            "Duplicate node names found: 'is_equal' (nodes: 3e3e3c467f618f64, 22cb5788ed6296b9)",
+        ),
     ],
 )
 async def test_invalid_flows(filename, in_values, expected_error):


### PR DESCRIPTION
This pull request introduces a new validator to ensure node names are unique within a graph and adds comprehensive test coverage for this validation. The main changes include the implementation of the validator, a new invalid test resource, and an additional test case.

**Validation logic:**

* Added `UniqueNodeNameValidator` in `unique_node_name.py` to check that all node names (excluding "Input" and "Output") are unique within the graph, returning a detailed error message if duplicates are found.

**Testing:**

* Added a new invalid graph resource `duplicate-node-names.json` containing nodes with duplicate names to test the validator.
* Extended the test suite in `test_executor.py` to include a case that expects a duplicate node name error when processing the new resource.