### PR TITLE
Improve Execution Serialization With Streaming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "retrack"
-version = "3.4.0"
+version = "3.4.1a0"
 description = "A business rules engine"
 authors = ["Gabriel Guarisa <gabriel.guarisa@pier.digital>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "retrack"
-version = "3.4.1a0"
+version = "3.4.1"
 description = "A business rules engine"
 authors = ["Gabriel Guarisa <gabriel.guarisa@pier.digital>"]
 license = "MIT"

--- a/retrack/engine/base.py
+++ b/retrack/engine/base.py
@@ -8,8 +8,8 @@ from retrack.utils import constants, registry
 from retrack.engine.schemas import ExecutionSchema
 from retrack.utils.transformers import (
     serialize_connections,
-    explode_nodes_by_values,
-    normalize_execution_for_debug,
+    explode_nodes_by_values_iter,
+    normalize_execution_for_debug_iter,
     to_metadata,
 )
 
@@ -109,8 +109,9 @@ class Execution:
     def to_model(self) -> ExecutionSchema:
         return ExecutionSchema(**self.to_dict())
 
-    def to_normalized_dict(self) -> dict:
+    def to_normalized_dict(self) -> list:
         nodes_normalized = []
+        values_cache = {}
         for node in self.nodes.values():
             nodes_normalized.append(
                 {
@@ -122,22 +123,22 @@ class Execution:
                         node_id=node.id,
                         connection_type="input",
                         execution=self,
+                        values_cache=values_cache,
                     ),
                     "outputs": serialize_connections(
                         node.outputs,
                         node_id=node.id,
                         connection_type="output",
                         execution=self,
+                        values_cache=values_cache,
                     ),
                     "default": node.default(),
                     "data": to_metadata(node),
                 }
             )
 
-        exploded_nodes = explode_nodes_by_values(nodes_normalized)
-        normalized_records = normalize_execution_for_debug(exploded_nodes)
-
-        return normalized_records
+        exploded_nodes = explode_nodes_by_values_iter(nodes_normalized)
+        return list(normalize_execution_for_debug_iter(exploded_nodes))
 
     @classmethod
     def from_dict(cls, data: dict):

--- a/retrack/utils/transformers.py
+++ b/retrack/utils/transformers.py
@@ -48,8 +48,14 @@ def to_metadata(node: BaseNode) -> typing.List[dict]:
 
 def serialize_value(value: typing.Any) -> typing.Any:
     """Serialize primitive-like values to JSON-friendly types."""
-    if value is None or pd.isna(value):
+    if value is None:
         return None
+
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
 
     if isinstance(
         value, (pd.Timestamp, datetime.datetime, datetime.date, datetime.time)
@@ -65,11 +71,8 @@ def serialize_value(value: typing.Any) -> typing.Any:
     if isinstance(value, dict):
         return {key: serialize_value(item) for key, item in value.items()}
 
-    try:
-        if hasattr(value, "item"):
-            return serialize_value(value.item())
-    except Exception:
-        pass
+    if isinstance(value, str) and value in ("True", "False"):
+        return value == "True"
 
     return value
 

--- a/retrack/utils/transformers.py
+++ b/retrack/utils/transformers.py
@@ -1,5 +1,7 @@
 import typing
 
+import datetime
+
 import pandas as pd
 from retrack.nodes.base import BaseNode
 from retrack.utils.constants import EXCLUDED_NODE_TYPES, FILTER_SUFFIX, NULL_SUFFIX
@@ -44,11 +46,40 @@ def to_metadata(node: BaseNode) -> typing.List[dict]:
     return [{"name": key, "value": value} for key, value in filtered.items()]
 
 
+def serialize_value(value: typing.Any) -> typing.Any:
+    """Serialize primitive-like values to JSON-friendly types."""
+    if value is None or pd.isna(value):
+        return None
+
+    if isinstance(
+        value, (pd.Timestamp, datetime.datetime, datetime.date, datetime.time)
+    ):
+        return value.isoformat()
+
+    if isinstance(value, datetime.timedelta):
+        return value.total_seconds()
+
+    if isinstance(value, (list, tuple)):
+        return [serialize_value(item) for item in value]
+
+    if isinstance(value, dict):
+        return {key: serialize_value(item) for key, item in value.items()}
+
+    try:
+        if hasattr(value, "item"):
+            return serialize_value(value.item())
+    except Exception:
+        pass
+
+    return value
+
+
 def serialize_connections(
     inputs_or_outputs: typing.Any,
     node_id: str,
     connection_type: str,
     execution: "typing.Any",
+    values_cache: typing.Optional[dict] = None,
 ) -> list:
     """Transform connection models into serialized list with values and source name.
 
@@ -71,6 +102,8 @@ def serialize_connections(
     connection_target_key = "output" if connection_type == "input" else "input"
 
     serialized_connections = []
+    if values_cache is None:
+        values_cache = {}
     for (
         input_or_output_name,
         input_or_output,
@@ -87,13 +120,17 @@ def serialize_connections(
                 else:
                     state_key = f"{node_id}@{input_or_output_name}"
 
-                values = execution.get_state_data(
-                    state_key,
-                    constants=execution.constants,
-                    filter_by=None,
-                ).tolist()
-
-                values = [None if pd.isna(value) else value for value in values]
+                if state_key in values_cache:
+                    values = values_cache[state_key]
+                else:
+                    raw_values = execution.get_state_data(
+                        state_key,
+                        constants=execution.constants,
+                        filter_by=None,
+                    )
+                    values = raw_values.tolist()
+                    values = [serialize_value(value) for value in values]
+                    values_cache[state_key] = values
             except Exception:
                 values = []
 
@@ -116,22 +153,17 @@ def serialize_connections(
     return serialized_connections
 
 
-def explode_nodes_by_values(nodes: typing.List[dict]) -> typing.List[typing.List[dict]]:
-    """Explode nodes by values array into array of arrays per value index.
+def explode_nodes_by_values_iter(
+    nodes: typing.List[dict],
+) -> typing.Iterator[typing.List[dict]]:
+    """Yield nodes per value index, without materializing all indexes.
 
     For each node, finds all input/output values arrays and determines max length.
-    Returns a list of lists where each sublist contains all nodes for that value index,
-    with 'values' array replaced by 'value' (singular) containing the specific value
-    or null if missing/empty.
-
-    Args:
-        nodes: List of normalized node dictionaries
-
-    Returns:
-        List of lists: [[node1_idx0, node2_idx0, ...], [node1_idx1, node2_idx1, ...], ...]
+    Yields one list per index where each node has 'value' (singular) extracted from
+    the original 'values' array.
     """
     if not nodes:
-        return []
+        return
 
     max_length = 0
     for node in nodes:
@@ -141,8 +173,6 @@ def explode_nodes_by_values(nodes: typing.List[dict]) -> typing.List[typing.List
 
     if max_length == 0:
         max_length = 1
-
-    exploded_nodes_by_index = []
 
     for idx in range(max_length):
         nodes_for_index = []
@@ -186,26 +216,19 @@ def explode_nodes_by_values(nodes: typing.List[dict]) -> typing.List[typing.List
 
             nodes_for_index.append(exploded_node)
 
-        exploded_nodes_by_index.append(nodes_for_index)
-
-    return exploded_nodes_by_index
+        yield nodes_for_index
 
 
-def normalize_execution_for_debug(
-    exploded_nodes: typing.List[typing.List[dict]],
+def explode_nodes_by_values(nodes: typing.List[dict]) -> typing.List[typing.List[dict]]:
+    """Explode nodes by values array into array of arrays per value index."""
+    return list(explode_nodes_by_values_iter(nodes))
+
+
+def normalize_execution_for_debug_iter(
+    exploded_nodes: typing.Iterable[typing.List[dict]],
     apply_filters: bool = True,
-) -> typing.List[dict]:
-    """Transform exploded nodes into debug format with inputs, results, nodes, and connections.
-
-    Args:
-        exploded_nodes: List of lists from explode_nodes_by_values
-        apply_filters: Whether to apply exclusion filters (node types, void connections, null values)
-
-    Returns:
-        List of normalized records, one per value index
-    """
-    normalized_records = []
-
+) -> typing.Iterator[dict]:
+    """Yield normalized records in debug format, one per value index."""
     for nodes_at_index in exploded_nodes:
         inputs = []
         seen_input_names = set()
@@ -311,13 +334,22 @@ def normalize_execution_for_debug(
                         }
                     )
 
-        normalized_records.append(
-            {
-                "inputs": inputs,
-                "outputs": outputs,
-                "nodes": nodes_info,
-                "connections": connections,
-            }
-        )
+        yield {
+            "inputs": inputs,
+            "outputs": outputs,
+            "nodes": nodes_info,
+            "connections": connections,
+        }
 
-    return normalized_records
+
+def normalize_execution_for_debug(
+    exploded_nodes: typing.List[typing.List[dict]],
+    apply_filters: bool = True,
+) -> typing.List[dict]:
+    """Transform exploded nodes into debug format with inputs, results, nodes, and connections."""
+    return list(
+        normalize_execution_for_debug_iter(
+            exploded_nodes,
+            apply_filters=apply_filters,
+        )
+    )


### PR DESCRIPTION
This pull request refactors the normalization and serialization logic for node execution data, focusing on improved performance and memory efficiency. The main changes include switching from list-based to iterator-based processing for key transformation functions, introducing value serialization for JSON compatibility, and adding caching to avoid redundant computations.

Performance and memory improvements:

* Refactored `explode_nodes_by_values` and `normalize_execution_for_debug` functions to use iterator-based versions (`explode_nodes_by_values_iter`, `normalize_execution_for_debug_iter`), enabling streaming processing and reducing memory usage.
* Updated `to_normalized_dict` in `retrack/engine/base.py` to return a list and utilize iterator-based normalization, supporting large-scale data processing.

Serialization enhancements:

* Added `serialize_value` function to convert primitive-like values (including pandas and datetime types) to JSON-friendly formats, ensuring compatibility and consistency in serialized output.
* Integrated value serialization into `serialize_connections`, so all node values are properly serialized and cached for efficiency.

API and interface changes:

* Modified `serialize_connections` to accept a `values_cache` argument, preventing redundant computation of node values across multiple calls.

These changes collectively improve the efficiency, reliability, and compatibility of node execution data serialization and normalization.