### PR TITLE
Improve execution performance in RequestManager validation and Execution.has_ended

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "retrack"
-version = "3.5.0"
+version = "3.6.0a1"
 description = "A business rules engine"
 authors = ["Gabriel Guarisa <gabriel.guarisa@pier.digital>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "retrack"
-version = "3.6.0a1"
+version = "3.6.0a2"
 description = "A business rules engine"
 authors = ["Gabriel Guarisa <gabriel.guarisa@pier.digital>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "retrack"
-version = "3.6.0a3"
+version = "3.6.0a4"
 description = "A business rules engine"
 authors = ["Gabriel Guarisa <gabriel.guarisa@pier.digital>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "retrack"
-version = "3.6.0a4"
+version = "3.7.0"
 description = "A business rules engine"
 authors = ["Gabriel Guarisa <gabriel.guarisa@pier.digital>"]
 license = "MIT"

--- a/retrack/engine/base.py
+++ b/retrack/engine/base.py
@@ -95,7 +95,7 @@ class Execution:
         ]
 
     def has_ended(self) -> bool:
-        return self.states[constants.OUTPUT_REFERENCE_COLUMN].isna().sum() == 0
+        return not self.states[constants.OUTPUT_REFERENCE_COLUMN].isna().any()
 
     def to_dict(self) -> dict:
         return {

--- a/retrack/engine/base.py
+++ b/retrack/engine/base.py
@@ -21,7 +21,7 @@ class Execution:
         states: pd.DataFrame,
         filters: dict = None,
         context: registry.Registry = None,
-        child_executions = None,
+        child_executions=None,
         nodes: dict = None,
         constants: dict = None,
     ):

--- a/retrack/engine/request_manager.py
+++ b/retrack/engine/request_manager.py
@@ -1,7 +1,6 @@
 import typing
 
 import pandas as pd
-import pandera
 import pydantic
 
 from retrack.nodes.base import BaseNode, NodeKind
@@ -75,7 +74,7 @@ class RequestManager:
         return self._model
 
     @property
-    def dataframe_model(self) -> pandera.DataFrameSchema:
+    def dataframe_model(self):
         return self._dataframe_model
 
     def __create_model(
@@ -117,23 +116,19 @@ class RequestManager:
             ),
         )
 
-    def __create_dataframe_model(self) -> pandera.DataFrameSchema:
-        """Create a pydantic model from the RequestManager's inputs"""
-        fields = {}
-        for input_field in self.inputs:
-            fields[input_field.data.name] = pandera.Column(
-                str,
-                nullable=input_field.data.default is not None,
-                coerce=True,
-                default=input_field.data.default,
-            )
+    def __create_dataframe_model(self) -> dict:
+        """Create a lightweight validation schema from the RequestManager's inputs.
 
-        return pandera.DataFrameSchema(
-            fields,
-            index=pandera.Index(int),
-            # strict=True,
-            coerce=True,
-        )
+        Returns:
+            dict: mapping column_name -> {"nullable": bool, "default": value}
+        """
+        schema = {}
+        for input_field in self.inputs:
+            schema[input_field.data.name] = {
+                "nullable": input_field.data.default is not None,
+                "default": input_field.data.default,
+            }
+        return schema
 
     def validate(
         self,
@@ -156,4 +151,31 @@ class RequestManager:
         if not isinstance(payload, pd.DataFrame):
             raise TypeError(f"payload must be a pandas.DataFrame, not {type(payload)}")
 
-        return self.dataframe_model.validate(payload)
+        schema = self.dataframe_model
+
+        # Check required columns exist
+        missing = set(schema.keys()) - set(payload.columns)
+        if missing:
+            raise ValueError(
+                f"Missing columns: {missing}"
+            )
+
+        result = payload.copy()
+
+        for col_name, col_schema in schema.items():
+            series = result[col_name]
+
+            # Handle nulls
+            null_mask = series.isna() | series.isin([None, "None", "", "null"])
+            if null_mask.any():
+                if not col_schema["nullable"]:
+                    raise ValueError(
+                        f"Column '{col_name}' contains null values but is not nullable"
+                    )
+                if col_schema["default"] is not None:
+                    series = series.where(~null_mask, col_schema["default"])
+
+            # Coerce to str
+            result[col_name] = series.astype(str)
+
+        return result

--- a/retrack/engine/request_manager.py
+++ b/retrack/engine/request_manager.py
@@ -156,9 +156,7 @@ class RequestManager:
         # Check required columns exist
         missing = set(schema.keys()) - set(payload.columns)
         if missing:
-            raise ValueError(
-                f"Missing columns: {missing}"
-            )
+            raise ValueError(f"Missing columns: {missing}")
 
         result = payload.copy()
 

--- a/tests/test_engine/test_request_manager.py
+++ b/tests/test_engine/test_request_manager.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pandera
 import pydantic
 import pytest
 
@@ -41,7 +40,7 @@ def test_validate_payload_with_valid_payload(valid_input_dict_before_validation)
 
     assert issubclass(rm.model, pydantic.BaseModel)
 
-    assert isinstance(rm.dataframe_model, pandera.api.pandas.container.DataFrameSchema)
+    assert isinstance(rm.dataframe_model, dict)
 
     payload = rm.model(example="test")
 

--- a/tests/test_engine/test_request_manager.py
+++ b/tests/test_engine/test_request_manager.py
@@ -62,3 +62,29 @@ def test_validate_dict_with_none_value(valid_input_dict_before_validation):
     assert issubclass(rm.model, pydantic.BaseModel)
     assert rm.model(example=None) == rm.model(example="Hello World")
     assert rm.model() == rm.model(example="Hello World")
+
+
+def test_validate_dataframe_replaces_sentinel_strings_with_default(
+    valid_input_dict_before_validation,
+):
+    """Sentinel strings count as null in the DataFrame path, matching StrFieldValidator."""
+    rm = RequestManager([Input(**valid_input_dict_before_validation)])
+
+    result = rm.validate(
+        pd.DataFrame([{"example": v} for v in ["None", "", "null", None]])
+    )
+
+    assert result["example"].tolist() == ["Hello World"] * 4
+
+
+def test_validate_dataframe_rejects_sentinel_strings_when_not_nullable(
+    valid_input_dict_before_validation,
+):
+    """Without a default the input is not nullable, so sentinel strings must raise."""
+    rm = RequestManager(
+        [Input(**{**valid_input_dict_before_validation, "data": {"name": "example"}})]
+    )
+
+    for value in ["None", "", "null", None]:
+        with pytest.raises(ValueError, match="not nullable"):
+            rm.validate(pd.DataFrame([{"example": value}]))


### PR DESCRIPTION
## Summary

This PR improves rule execution performance by reducing overhead in two hot paths:

- replaces `pandera`-based DataFrame validation in `RequestManager.validate()` with a lightweight pandas-based validation flow
- optimizes `Execution.has_ended()` by switching from a full null-count scan to a short-circuit null check

## What Changed

- **`RequestManager`**
  - precomputes a lightweight schema as a plain dict instead of a `pandera.DataFrameSchema`
  - validates required columns manually
  - handles null/default substitution with vectorized pandas operations
  - coerces validated input columns to `str`
- **`Execution`**
  - changes `has_ended()` from `.isna().sum() == 0` to `not .isna().any()`
- **Tests**
  - updates the `RequestManager` test to match the new lightweight schema representation

## Motivation

The goal is to reduce validation overhead during rule execution, especially in smaller and latency-sensitive workloads where fixed framework costs dominate total runtime.

Local performance notes in the repository indicate that input validation was one of the main execution bottlenecks, and that `has_ended()` is called repeatedly during execution. These changes target both paths directly.

## Testing

- `poetry run pytest tests/test_engine/test_request_manager.py`

## Risks

- This PR changes validation semantics for DataFrame inputs:
  - `""`, `"null"` and `"None"` are now treated as null-like values during DataFrame validation
  - previously, under `pandera`, those values were accepted as valid strings
- If existing rules or clients rely on those literal string values, this change may be behavior-breaking

## Notes

This PR is intentionally small and focused on committed performance changes only:
- lightweight RequestManager validation
- `has_ended()` short-circuit optimization