### PR TITLE
Pin ruff version to ~0.15.22 to prevent breaking changes from ruff 0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ pandera = "~0.20"
 pytest-asyncio = "^1.1.0"
 pytest = "*"
 pytest-cov = "*"
-ruff = "*"
+ruff = "~0.15.22"
 pytest-mock = "*"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This pull request makes a minor update to the development dependencies by specifying an exact version for the `ruff` linter in `pyproject.toml`. This helps ensure consistent linting results across different environments.

* Dependency management:
  * Updated the `ruff` dependency version from any version to `~0.15.22` in `pyproject.toml` to lock the linter to a specific version.