### PR TITLE
Return the output node message as a named output entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "retrack"
-version = "3.7.0"
+version = "3.8.0a0"
 description = "A business rules engine"
 authors = ["Gabriel Guarisa <gabriel.guarisa@pier.digital>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "retrack"
-version = "3.8.0a0"
+version = "3.8.0"
 description = "A business rules engine"
 authors = ["Gabriel Guarisa <gabriel.guarisa@pier.digital>"]
 license = "MIT"

--- a/retrack/utils/transformers.py
+++ b/retrack/utils/transformers.py
@@ -265,6 +265,8 @@ def normalize_execution_for_debug_iter(
                     message = item.get("value")
                     break
 
+            outputs_before = len(outputs)
+
             if node_type == "Output":
                 if not inputs_list:
                     continue
@@ -296,6 +298,15 @@ def normalize_execution_for_debug_iter(
                                 "message": message,
                             }
                         )
+
+            if message is not None and len(outputs) > outputs_before:
+                outputs.append(
+                    {
+                        "name": "message",
+                        "value": message,
+                        "message": message,
+                    }
+                )
 
         nodes_info = [
             {

--- a/tests/resources/executions/multiple-ifs.json
+++ b/tests/resources/executions/multiple-ifs.json
@@ -11,6 +11,11 @@
         "name": "output",
         "value": "1",
         "message": "first"
+      },
+      {
+        "name": "message",
+        "value": "first",
+        "message": "first"
       }
     ],
     "nodes": [
@@ -173,6 +178,11 @@
       {
         "name": "output",
         "value": "2",
+        "message": "second"
+      },
+      {
+        "name": "message",
+        "value": "second",
         "message": "second"
       }
     ],

--- a/tests/test_transformers/test_normalize_debug.py
+++ b/tests/test_transformers/test_normalize_debug.py
@@ -37,7 +37,8 @@ def test_output_single_value():
     )
     result = _normalize([node])
     assert result[0]["outputs"] == [
-        {"name": "output", "value": 3028, "message": "basic"}
+        {"name": "output", "value": 3028, "message": "basic"},
+        {"name": "message", "value": "basic", "message": "basic"},
     ]
 
 
@@ -92,6 +93,55 @@ def test_output_filters_nan_value():
     assert result[0]["outputs"] == []
 
 
+def test_output_without_value_does_not_emit_message():
+    node = _make_node(
+        "Output",
+        inputs=[
+            {
+                "node_id": "n0",
+                "target_name": "input_value",
+                "value": None,
+                "source_name": "output",
+            }
+        ],
+        data=[{"name": "message", "value": "not executed"}],
+    )
+    result = _normalize([node])
+    assert result[0]["outputs"] == []
+
+
+def test_only_executed_output_node_emits_message():
+    executed = _make_node(
+        "Output",
+        inputs=[
+            {
+                "node_id": "a",
+                "target_name": "input_value",
+                "value": 10,
+                "source_name": "output",
+            }
+        ],
+        data=[{"name": "message", "value": "taken"}],
+    )
+    skipped = _make_node(
+        "Output",
+        inputs=[
+            {
+                "node_id": "b",
+                "target_name": "input_value",
+                "value": None,
+                "source_name": "output",
+            }
+        ],
+        data=[{"name": "message", "value": "not taken"}],
+    )
+    result = _normalize([executed, skipped])
+    assert result[0]["outputs"] == [
+        {"name": "output", "value": 10, "message": "taken"},
+        {"name": "message", "value": "taken", "message": "taken"},
+    ]
+
+
 def test_output_empty_inputs():
     node = _make_node("Output", inputs=[], data=[{"name": "message", "value": "x"}])
     result = _normalize([node])
@@ -133,6 +183,7 @@ def test_multiple_outputs_expands_all_keys():
         {"name": "basic_7", "value": 3028, "message": "cobertura"},
         {"name": "basic_15", "value": 7194, "message": "cobertura"},
         {"name": "basic_30", "value": 15720, "message": "cobertura"},
+        {"name": "message", "value": "cobertura", "message": "cobertura"},
     ]
 
 
@@ -147,7 +198,8 @@ def test_multiple_outputs_replicates_message_on_all_entries():
     )
     result = _normalize([node])
     messages = [e["message"] for e in result[0]["outputs"]]
-    assert messages == ["msg", "msg"]
+    assert messages == ["msg", "msg", "msg"]
+    assert [e["name"] for e in result[0]["outputs"]] == ["k1", "k2", "message"]
 
 
 def test_multiple_outputs_message_none():
@@ -223,7 +275,10 @@ def test_multiple_outputs_single_key():
         data=[{"name": "message", "value": "solo"}],
     )
     result = _normalize([node])
-    assert result[0]["outputs"] == [{"name": "only_key", "value": 7, "message": "solo"}]
+    assert result[0]["outputs"] == [
+        {"name": "only_key", "value": 7, "message": "solo"},
+        {"name": "message", "value": "solo", "message": "solo"},
+    ]
 
 
 def test_multiple_outputs_preserves_order():
@@ -277,4 +332,7 @@ def test_output_and_non_terminal_together():
     )
     other = _make_node("Math", inputs=[])
     result = _normalize([output_node, other])
-    assert result[0]["outputs"] == [{"name": "output", "value": 5, "message": "ok"}]
+    assert result[0]["outputs"] == [
+        {"name": "output", "value": 5, "message": "ok"},
+        {"name": "message", "value": "ok", "message": "ok"},
+    ]


### PR DESCRIPTION
## What

The `message` field of `Output` and `MultipleOutputs` nodes now shows up as a regular entry in the normalized `outputs` list, using `message` as its name.

Before:

```json
"outputs": [
  { "name": "output", "value": "1", "message": "first" }
]
```

After:

```json
"outputs": [
  { "name": "output", "value": "1", "message": "first" },
  { "name": "message", "value": "first", "message": "first" }
]
```

## Why

Consumers of `Execution.to_normalized_dict()` read the `outputs` list as a flat collection of named values. The message was only reachable as an extra key inside each value entry, so anyone treating the list uniformly never saw it. Exposing it as its own named entry makes the message available through the same access pattern as every other output.

## How

The change lives in `normalize_execution_for_debug_iter` in `retrack/utils/transformers.py`. For each terminal node we now count how many entries it contributed and append a single `message` entry right after them.

Rules applied:

1. A null message produces no entry at all.
2. A terminal node that produced no value, meaning it was not the path taken for that record, produces neither a value nor a message. This keeps the message scoped to the branch that actually ran, which matters for graphs with several `Output` nodes.
3. `MultipleOutputs` emits one message entry after all of its keys instead of repeating the message on every key.

## Backwards compatibility

The inline `message` key stays on the value entries, so existing readers keep working. The new entry also carries a `message` key with the same content, which means every dict in `outputs` still has the same shape and code that reads `entry["message"]` across the whole list will not raise a `KeyError`.

Released as `3.8.0a0` so the new shape can be validated by a consumer before the final minor.

## Testing

Five expectations in `tests/test_transformers/test_normalize_debug.py` were updated and two cases were added, one covering a filled message on a node without a value and one covering a graph where only the executed `Output` emits its message. The `tests/resources/executions/multiple-ifs.json` fixture was regenerated. Full suite passes with 139 tests.